### PR TITLE
1-CLI-HELP Edited CLI help: Clarified --csv, fixed --no-progress.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,13 +18,13 @@ module.exports = function({
 } = {}) {
 
   program
-    .arguments('[assemblyFile]')
-    .option('--no-progress', 'Show progress bar')
+    .arguments('ASSEMBLY_FILE')
+    .option('--no-progress', 'Hide progress bar.')
     //.option('-c, --config [config]', 'Use a JSON config file')
-    .option('-q, --quiet', 'Display errors only')
-    .option('--csv', 'Output in CSV format')
-    .option('-n, --dry', 'Dry run')
-    .option('--asciibinder', 'Support asciibinder style include directives')
+    .option('-q, --quiet', 'Display errors only.')
+    .option('--csv', 'Output to stdout in CSV format. Outputs BROKEN_LINK,MODULE,LINE_NUM. If you want to create a CSV file, either copy the output from stdout to a text file after running the tool, or redirect the output to a text file. This option implies --no-progress and --quiet.')
+    .option('-n, --dry', 'Dry run.')
+    .option('--asciibinder', 'Support asciibinder style include directives.')
     .action(main({ linkExtractor, linkChecker }));
 
   return {


### PR DESCRIPTION
Made some fixes to CLI help to clarify usage.

I'd like to change the usage info also to say something like:

`Usage: asciidoc-aware-link-check [options] ASSEMBLY_FILE`

I want to indicate that you must include an assembly file. Brackets indicates an argument is optional.